### PR TITLE
Refactor example, split example to separate VS project.

### DIFF
--- a/MenuExample.cs
+++ b/MenuExample.cs
@@ -8,24 +8,26 @@ using NativeUI;
 
 public class MenuExample : Script
 {
-    private UIMenu mainMenu;
-    private UIMenu newMenu;
-    private UIMenuCheckboxItem ketchupCheckbox;
-    private UIMenuListItem dishesListItem;
-    private UIMenuItem cookItem;
-
+    private bool ketchup = false;
+    private string dish = "Banana";
     private MenuPool _menuPool;
 
-    public MenuExample()
+    public void AddMenuKetchup(UIMenu menu)
     {
-        Tick += OnTick;
-        KeyDown += OnKeyDown;
-        _menuPool = new MenuPool();
+        var newitem = new UIMenuCheckboxItem("Add ketchup?", ketchup, "Do you wish to add ketchup?");
+        menu.AddItem(newitem);
+        menu.OnCheckboxChange += (sender, item, checked_) =>
+        {
+            if (item == newitem)
+            {
+                ketchup = checked_;
+                UI.Notify("~r~Ketchup status: ~b~" + ketchup);
+            }
+        };
+    }
 
-        mainMenu = new UIMenu("Native UI", "~b~NATIVEUI SHOWCASE");
-        _menuPool.Add(mainMenu);
-
-        mainMenu.AddItem(ketchupCheckbox = new UIMenuCheckboxItem("Add ketchup?", false, "Do you wish to add ketchup?"));
+    public void AddMenuFoods(UIMenu menu)
+    {
         var foods = new List<dynamic>
         {
             "Banana",
@@ -34,72 +36,63 @@ public class MenuExample : Script
             "Quartilicious",
             0xF00D, // Dynamic!
         };
-        mainMenu.AddItem(dishesListItem = new UIMenuListItem("Food", foods, 0));
-        mainMenu.AddItem(cookItem = new UIMenuItem("Cook!", "Cook the dish with the appropiate ingredients and ketchup."));
+        var newitem = new UIMenuListItem("Food", foods, 0);
+        menu.AddItem(newitem);
+        menu.OnListChange += (sender, item, index) =>
+        {
+            if (item == newitem)
+            {
+                dish = item.IndexToItem(index).ToString();
+                UI.Notify("Preparing ~b~" + dish + "~w~...");
+            }
 
-        var menuItem = new UIMenuItem("Go to another menu.");
-        mainMenu.AddItem(menuItem);
-        cookItem.SetLeftBadge(UIMenuItem.BadgeStyle.Star);
-        cookItem.SetRightBadge(UIMenuItem.BadgeStyle.Tick);
-        mainMenu.RefreshIndex();
+        };
+    }
 
-        mainMenu.OnItemSelect += OnItemSelect;
-        mainMenu.OnListChange += OnListChange;
-        mainMenu.OnCheckboxChange += OnCheckboxChange;
-        mainMenu.OnIndexChange += OnItemChange;
+    public void AddMenuCook(UIMenu menu)
+    {
+        var newitem = new UIMenuItem("Cook!", "Cook the dish with the appropiate ingredients and ketchup.");
+        newitem.SetLeftBadge(UIMenuItem.BadgeStyle.Star);
+        newitem.SetRightBadge(UIMenuItem.BadgeStyle.Tick);
+        menu.AddItem(newitem);
+        menu.OnItemSelect += (sender, item, index) =>
+        {
+            if (item == newitem)
+            {
+                string output = ketchup ? "You have ordered ~b~{0}~w~ ~r~with~w~ ketchup." : "You have ordered ~b~{0}~w~ ~r~without~w~ ketchup.";
+                UI.ShowSubtitle(String.Format(output, dish));
+            }
+        };
+        menu.OnIndexChange += (sender, index) =>
+        {
+            if (sender.MenuItems[index] == newitem)
+                newitem.SetLeftBadge(UIMenuItem.BadgeStyle.None);
+        };
+    }
 
-        newMenu = new UIMenu("Native UI", "~r~NATIVEUI SHOWCASE");
-        _menuPool.Add(newMenu);
+    public void AddMenuAnotherMenu(UIMenu menu)
+    {
+        var submenu = _menuPool.AddSubMenu(menu, "Another Menu");
         for (int i = 0; i < 20; i++)
+            submenu.AddItem(new UIMenuItem("PageFiller", "Sample description that takes more than one line. Moreso, it takes way more than two lines since it's so long. Wow, check out this length!"));
+    }
+
+    public MenuExample()
+    {
+        _menuPool = new MenuPool();
+        var mainMenu = new UIMenu("Native UI", "~b~NATIVEUI SHOWCASE");
+        _menuPool.Add(mainMenu);
+        AddMenuKetchup(mainMenu);
+        AddMenuFoods(mainMenu);
+        AddMenuCook(mainMenu);
+        AddMenuAnotherMenu(mainMenu);
+        _menuPool.RefreshIndex();
+
+        Tick += (o, e) => _menuPool.ProcessMenus();
+        KeyDown += (o, e) =>
         {
-            newMenu.AddItem(new UIMenuItem("PageFiller", "Sample description that takes more than one line. Moreso, it takes way more than two lines since it's so long. Wow, check out this length!"));
-        }
-        newMenu.RefreshIndex();
-        mainMenu.BindMenuToItem(newMenu, menuItem);
-        
-    }
-
-    public void OnItemChange(UIMenu sender, int index)
-    {
-        sender.MenuItems[index].SetLeftBadge(UIMenuItem.BadgeStyle.None);
-    }
-
-    public void OnCheckboxChange(UIMenu sender, UIMenuCheckboxItem checkbox, bool Checked)
-    {
-        if (sender != mainMenu || checkbox != ketchupCheckbox) return; // We only want to detect changes from our menu.
-        UI.Notify("~r~Ketchup status: ~b~" + Checked);
-    }
-
-    public void OnListChange(UIMenu sender, UIMenuListItem list, int index)
-    {
-        if (sender != mainMenu || list != dishesListItem) return; // We only want to detect changes from our menu.
-        string dish = list.IndexToItem(index).ToString();
-        UI.Notify("Preparing ~b~" + dish +"~w~...");
-    }
-    
-    public void OnItemSelect(UIMenu sender, UIMenuItem selectedItem, int index)
-    {
-        if (sender != mainMenu || selectedItem != cookItem) return; // We only want to detect changes from our menu and our button.
-        // You can also detect the button by using index
-        string dish = dishesListItem.IndexToItem(dishesListItem.Index).ToString();
-        bool ketchup = ketchupCheckbox.Checked;
-
-        string output = ketchup
-            ? "You have ordered ~b~{0}~w~ ~r~with~w~ ketchup."
-            : "You have ordered ~b~{0}~w~ ~r~without~w~ ketchup.";
-        UI.ShowSubtitle(String.Format(output, dish));
-    }
-
-    public void OnTick(object o, EventArgs e)
-    {
-        _menuPool.ProcessMenus();
-    }
-
-    public void OnKeyDown(object o, KeyEventArgs e)
-    {
-        if (e.KeyCode == Keys.F5 && !_menuPool.IsAnyMenuOpen()) // Our menu on/off switch
-        {
-            mainMenu.Visible = !mainMenu.Visible;
-        }
+            if (e.KeyCode == Keys.F5 && !_menuPool.IsAnyMenuOpen()) // Our menu on/off switch
+                mainMenu.Visible = !mainMenu.Visible;
+        };
     }
 }

--- a/MenuExample.csproj
+++ b/MenuExample.csproj
@@ -1,17 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F3E16ED9-DBF7-4E7B-B04B-9B24B11891D3}</ProjectGuid>
+    <ProjectGuid>{79D9A09F-1999-4148-9BA0-20AEBA9B3C8B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NativeUI</RootNamespace>
-    <AssemblyName>NativeUI</AssemblyName>
+    <RootNamespace>MenuExample</RootNamespace>
+    <AssemblyName>MenuExample</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +20,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,16 +28,16 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ScriptHookVDotNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Rockstar Games\Grand Theft Auto V\ScriptHookVDotNet.dll</HintPath>
+    <Reference Include="NativeUI">
+      <HintPath>..\..\NativeUI.dll</HintPath>
+    </Reference>
+    <Reference Include="ScriptHookVDotNet">
+      <HintPath>..\..\ScriptHookVDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -49,22 +47,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="InstructionalButton.cs" />
-    <Compile Include="MenuPool.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Sprite.cs" />
-    <Compile Include="StringMeasurer.cs" />
-    <Compile Include="UIMenu.cs" />
-    <Compile Include="UIMenuCheckboxItem.cs" />
-    <Compile Include="UIMenuItem.cs" />
-    <Compile Include="UIMenuListItem.cs" />
-    <Compile Include="UIResRectangle.cs" />
-    <Compile Include="UIResText.cs" />
+    <Compile Include="MenuExample.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "A:\Program Files\Rockstar Games\Grand Theft Auto V\scripts\$(TargetFileName)"</PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NativeUI.sln
+++ b/NativeUI.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeUI", "NativeUI.csproj", "{F3E16ED9-DBF7-4E7B-B04B-9B24B11891D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MenuExample", "MenuExample.csproj", "{79D9A09F-1999-4148-9BA0-20AEBA9B3C8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{F3E16ED9-DBF7-4E7B-B04B-9B24B11891D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3E16ED9-DBF7-4E7B-B04B-9B24B11891D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3E16ED9-DBF7-4E7B-B04B-9B24B11891D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79D9A09F-1999-4148-9BA0-20AEBA9B3C8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79D9A09F-1999-4148-9BA0-20AEBA9B3C8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79D9A09F-1999-4148-9BA0-20AEBA9B3C8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79D9A09F-1999-4148-9BA0-20AEBA9B3C8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Here's another bit of code I wanted to send your way. This one concerns your menu example.

The idea is that one can use lambda expressions and exploit function closures to make the code much more local, keeping less state, and therefore being more comprehensible. In the example, the actions are defined along with where the items are added to the menus. It is therefore much easier to follow what goes on (of course that's opinion, I understand if you disagree). This might help other modders to get started more quickly with your plugin. Basically one creates a function for each menu item: this one function takes care of both adding the item to the menu and the actions related to the item.

I've also added a project for the example script so it will be compiled. Note that it refers to my local assemblies but that's easy to fix.