### PR TITLE
Add complete UTF-8 support

### DIFF
--- a/Elements/UIResText.cs
+++ b/Elements/UIResText.cs
@@ -39,67 +39,67 @@ namespace NativeUI
         /// <param name="str"></param>
         public static void AddLongString(string str)
         {
-			var utf8ByteCount = System.Text.Encoding.UTF8.GetByteCount(str);
+            var utf8ByteCount = System.Text.Encoding.UTF8.GetByteCount(str);
 
-			if (utf8ByteCount == str.Length)
-			{
-				AddLongStringForAscii(str);
-			}
-			else
-			{
-				AddLongStringForUtf8(str);
-			}
-		}
+            if (utf8ByteCount == str.Length)
+            {
+                AddLongStringForAscii(str);
+            }
+            else
+            {
+                AddLongStringForUtf8(str);
+            }
+        }
 
-		private static void AddLongStringForAscii(string input)
-		{
+        private static void AddLongStringForAscii(string input)
+        {
             const int maxByteLengthPerString = 99;
 
-			for (int i = 0; i < input.Length; i += maxByteLengthPerString)
-			{
-				string substr = (input.Substring(i * maxByteLengthPerString, Math.Min(maxByteLengthPerString, input.Length - i * maxByteLengthPerString)));
-				Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
-			}
-		}
+            for (int i = 0; i < input.Length; i += maxByteLengthPerString)
+            {
+                string substr = (input.Substring(i * maxByteLengthPerString, Math.Min(maxByteLengthPerString, input.Length - i * maxByteLengthPerString)));
+                Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
+            }
+        }
 
-		private static void AddLongStringForUtf8(string input)
-		{
+        private static void AddLongStringForUtf8(string input)
+        {
             const int maxByteLengthPerString = 99;
 
             if (maxByteLengthPerString < 0)
-			{
-				throw new ArgumentOutOfRangeException("maxLengthPerString");
-			}
-			if (string.IsNullOrEmpty(input) || maxByteLengthPerString == 0)
-			{
-				return;
-			}
+            {
+                throw new ArgumentOutOfRangeException("maxLengthPerString");
+            }
+            if (string.IsNullOrEmpty(input) || maxByteLengthPerString == 0)
+            {
+                return;
+            }
 
-			var enc = System.Text.Encoding.UTF8;
+            var enc = System.Text.Encoding.UTF8;
 
-			var utf8ByteCount = enc.GetByteCount(input);
-			if (utf8ByteCount < maxByteLengthPerString)
-			{
-				Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, input);
-				return;
-			}
+            var utf8ByteCount = enc.GetByteCount(input);
+            if (utf8ByteCount < maxByteLengthPerString)
+            {
+                Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, input);
+                return;
+            }
 
-			var startIndex = 0;
+            var startIndex = 0;
 
-			for (int i = 0; i < input.Length; i++)
-			{
-				var length = i - startIndex;
-				if (enc.GetByteCount(input.Substring(startIndex, length)) > maxByteLengthPerString)
-				{
-					string substr = (input.Substring(startIndex, length - 1));
-					Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
+            for (int i = 0; i < input.Length; i++)
+            {
+                var length = i - startIndex;
+                if (enc.GetByteCount(input.Substring(startIndex, length)) > maxByteLengthPerString)
+                {
+                    string substr = (input.Substring(startIndex, length - 1));
+                    Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
 
-					i -= 1;
-					startIndex = (startIndex + length - 1);
-				}
-			}
-			Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, input.Substring(startIndex, input.Length - startIndex));
-		}
+                    i -= 1;
+                    startIndex = (startIndex + length - 1);
+                }
+            }
+            Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, input.Substring(startIndex, input.Length - startIndex));
+        }
 
         public static float MeasureStringWidth(string str, Font font, float scale)
         {

--- a/Elements/UIResText.cs
+++ b/Elements/UIResText.cs
@@ -39,14 +39,68 @@ namespace NativeUI
         /// <param name="str"></param>
         public static void AddLongString(string str)
         {
-            const int strLen = 99;
-            for (int i = 0; i < str.Length; i += strLen)
-            {
-                string substr = str.Substring(i, Math.Min(strLen, str.Length - i));
-                Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
-            }
-        }
-        
+			var utf8ByteCount = System.Text.Encoding.UTF8.GetByteCount(str);
+
+			if (utf8ByteCount == str.Length)
+			{
+				AddLongStringForAscii(str);
+			}
+			else
+			{
+				AddLongStringForUtf8(str);
+			}
+		}
+
+		private static void AddLongStringForAscii(string input)
+		{
+            const int maxByteLengthPerString = 99;
+
+			for (int i = 0; i < input.Length; i += maxByteLengthPerString)
+			{
+				string substr = (input.Substring(i * maxByteLengthPerString, Math.Min(maxByteLengthPerString, input.Length - i * maxByteLengthPerString)));
+				Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
+			}
+		}
+
+		private static void AddLongStringForUtf8(string input)
+		{
+            const int maxByteLengthPerString = 99;
+
+            if (maxByteLengthPerString < 0)
+			{
+				throw new ArgumentOutOfRangeException("maxLengthPerString");
+			}
+			if (string.IsNullOrEmpty(input) || maxByteLengthPerString == 0)
+			{
+				return;
+			}
+
+			var enc = System.Text.Encoding.UTF8;
+
+			var utf8ByteCount = enc.GetByteCount(input);
+			if (utf8ByteCount < maxByteLengthPerString)
+			{
+				Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, input);
+				return;
+			}
+
+			var startIndex = 0;
+
+			for (int i = 0; i < input.Length; i++)
+			{
+				var length = i - startIndex;
+				if (enc.GetByteCount(input.Substring(startIndex, length)) > maxByteLengthPerString)
+				{
+					string substr = (input.Substring(startIndex, length - 1));
+					Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
+
+					i -= 1;
+					startIndex = (startIndex + length - 1);
+				}
+			}
+			Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, input.Substring(startIndex, input.Length - startIndex));
+		}
+
         public static float MeasureStringWidth(string str, Font font, float scale)
         {
             int screenw = 2560;// Game.ScreenResolution.Width;
@@ -63,7 +117,7 @@ namespace NativeUI
             AddLongString(str);
             return Function.Call<float>((Hash)0x85F061DA64ED2F67, (int)font) * scale;
         }
-        
+
         public Size WordWrap { get; set; }
 
         public override void Draw(Size offset)
@@ -97,13 +151,13 @@ namespace NativeUI
 
             if (WordWrap.Width != 0)
             {
-                float xsize = (Position.X + WordWrap.Width)/width;
+                float xsize = (Position.X + WordWrap.Width) / width;
                 Function.Call(Hash.SET_TEXT_WRAP, x, xsize);
             }
 
             Function.Call(Hash._SET_TEXT_ENTRY, "jamyfafi");
             AddLongString(Caption);
-            
+
             Function.Call(Hash._DRAW_TEXT, x, y);
         }
 

--- a/Elements/UIResText.cs
+++ b/Elements/UIResText.cs
@@ -57,7 +57,7 @@ namespace NativeUI
 
             for (int i = 0; i < input.Length; i += maxByteLengthPerString)
             {
-                string substr = (input.Substring(i * maxByteLengthPerString, Math.Min(maxByteLengthPerString, input.Length - i * maxByteLengthPerString)));
+                string substr = (input.Substring(i, Math.Min(maxByteLengthPerString, input.Length - i)));
                 Function.Call(Hash._ADD_TEXT_COMPONENT_STRING, substr);
             }
         }

--- a/PauseMenu/TabView.cs
+++ b/PauseMenu/TabView.cs
@@ -30,6 +30,8 @@ namespace NativeUI.PauseMenu
         public bool CanLeave { get; set; }
         public bool HideTabs { get; set; }
 
+        internal readonly static string _browseTextLocalized = Game.GetGXTEntry("HUD_INPUT1C");
+
         public event EventHandler OnMenuClose;
 
         public bool Visible
@@ -74,11 +76,11 @@ namespace NativeUI.PauseMenu
             _sc.CallFunction("CREATE_CONTAINER");
 
 
-            _sc.CallFunction("SET_DATA_SLOT", 0, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneSelect, 0), "Select");
-            _sc.CallFunction("SET_DATA_SLOT", 1, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneCancel, 0), "Back");
+            _sc.CallFunction("SET_DATA_SLOT", 0, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneSelect, 0), UIMenu._selectTextLocalized);
+            _sc.CallFunction("SET_DATA_SLOT", 1, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneCancel, 0), UIMenu._backTextLocalized);
 
             _sc.CallFunction("SET_DATA_SLOT", 2, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.FrontendRb, 0), "");
-            _sc.CallFunction("SET_DATA_SLOT", 3, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.FrontendLb, 0), "Browse");
+            _sc.CallFunction("SET_DATA_SLOT", 3, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.FrontendLb, 0), _browseTextLocalized);
         }
 
         public void DrawInstructionalButton(int slot, Control control, string text)

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -75,6 +75,9 @@ namespace NativeUI
         private Point _offset;
         private readonly int _extraYOffset;
 
+        internal readonly static string _selectTextLocalized = Game.GetGXTEntry("HUD_INPUT2");
+        internal readonly static string _backTextLocalized = Game.GetGXTEntry("HUD_INPUT3");
+
         #endregion
 
         #region Public Fields
@@ -1237,8 +1240,8 @@ namespace NativeUI
             _instructionalButtonsScaleform.CallFunction("CREATE_CONTAINER");
 
 
-            _instructionalButtonsScaleform.CallFunction("SET_DATA_SLOT", 0, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneSelect, 0), "Select");
-            _instructionalButtonsScaleform.CallFunction("SET_DATA_SLOT", 1, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneCancel, 0), "Back");
+            _instructionalButtonsScaleform.CallFunction("SET_DATA_SLOT", 0, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneSelect, 0), _selectTextLocalized);
+            _instructionalButtonsScaleform.CallFunction("SET_DATA_SLOT", 1, Function.Call<string>(Hash._0x0499D7B09FC9B407, 2, (int)Control.PhoneCancel, 0), _backTextLocalized);
             int count = 2;
             foreach (var button in _instructionalButtons.Where(button => button.ItemBind == null || MenuItems[CurrentSelection] == button.ItemBind))
             {


### PR DESCRIPTION
Now NativeUI can handle long multibyte strings! 🎉
Don't worry about FPS drop, this can't cause as much FPS drop as calling `Enum.GetValues` every frame does.
Unlike the default interaction menu, line wrapping doesn't work well without spaces, though...
(Btw, I use [my custom font](https://www.gta5-mods.com/misc/better-japanese-font-kagikn).)
![271590_20170822133042_1](https://user-images.githubusercontent.com/9353978/29548817-d8bc6e7a-873e-11e7-85af-9be1f64a0a5e.png)
![271590_20170822133040_1](https://user-images.githubusercontent.com/9353978/29548818-d8bf47d0-873e-11e7-95cc-4d4ea3916013.png)

[The example texts are available here.](https://gist.github.com/kagikn/c936d496ed4549a97ea4362da7fad239)