### PR TITLE
Fix Deprecated functions on SHVDN

### DIFF
--- a/BigMessage.cs
+++ b/BigMessage.cs
@@ -19,8 +19,7 @@ namespace NativeUI
         public void Load()
         {
             if (_sc != null) return;
-            _sc = new Scaleform(0);
-            _sc.Load("MP_BIG_MESSAGE_FREEMODE");
+            _sc = new Scaleform("MP_BIG_MESSAGE_FREEMODE");
             var timeout = 1000;
             var start = DateTime.Now;
             while (!Function.Call<bool>(Hash.HAS_SCALEFORM_MOVIE_LOADED, _sc.Handle) && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) Script.Yield();

--- a/PauseMenu/TabView.cs
+++ b/PauseMenu/TabView.cs
@@ -272,8 +272,8 @@ namespace NativeUI.PauseMenu
                     activeSize -= 4 * 5;
                     int tabWidth = (int)activeSize / Tabs.Count;
 
-                    Game.EnableControl(0, Control.CursorX);
-                    Game.EnableControl(0, Control.CursorY);
+                    Game.EnableControlThisFrame(0, Control.CursorX);
+                    Game.EnableControlThisFrame(0, Control.CursorY);
 
                     var hovering = UIMenu.IsMouseInBounds(safe.AddPoints(new Point((tabWidth + 5) * i, 0)),
                         new Size(tabWidth, 40));

--- a/PauseMenu/TabView.cs
+++ b/PauseMenu/TabView.cs
@@ -67,8 +67,7 @@ namespace NativeUI.PauseMenu
         {
             if (_sc == null)
             {
-                _sc = new Scaleform(0);
-                _sc.Load("instructional_buttons");
+                _sc = new Scaleform("instructional_buttons");
             }
 
             _sc.CallFunction("CLEAR_ALL");

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -231,8 +231,7 @@ namespace NativeUI
             Children = new Dictionary<UIMenuItem, UIMenu>();
             WidthOffset = 0;
 
-            _instructionalButtonsScaleform = new Scaleform(0);
-            _instructionalButtonsScaleform.Load("instructional_buttons");
+            _instructionalButtonsScaleform = new Scaleform("instructional_buttons");
             UpdateScaleform();
 
             _mainMenu = new UIContainer(new Point(0, 0), new Size(700, 500), Color.FromArgb(0, 0, 0, 0));


### PR DESCRIPTION
* Scaleform objects are now created by the string name
* EnableControl was marked as obsolete and it was replaced by EnableControlThisFrame that does the same

Please note that I did not tested the commits in-game.
