### PR TITLE
Added information to make a NuGet package

### DIFF
--- a/NativeUI.csproj
+++ b/NativeUI.csproj
@@ -76,6 +76,7 @@
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="NativeUI.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/NativeUI.nuspec
+++ b/NativeUI.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>NativeUI</id>
+    <version>1.7</version>
+    <authors>Guad</authors>
+    <licenseUrl>https://github.com/Guad/NativeUI/blob/master/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/Guad/NativeUI</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>NativeUI is a ScriptHookDotNet based library that helps you quickly and easily build Rockstar-like menus.</description>
+    <tags>gta gtav shvdn</tags>
+    <dependencies>
+      <dependency id="ScriptHookVDotNet2" version="2.10.7" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\x64\Release\NativeUI.dll" target="lib\net452" />
+  </files>
+</package>


### PR DESCRIPTION
This PR adds a NuGet .nuspec file that allows you to build the NuGet version of NativeUI.

The package is built correctly on my side:

```
D:\Proyectos\NativeUI>E:\Descargas\nuget.exe pack NativeUI.nuspec
Attempting to build package from 'NativeUI.nuspec'.
Successfully created package 'D:\Proyectos\NativeUI\NativeUI.1.7.0.nupkg'.

D:\Proyectos\NativeUI>E:\Descargas\nuget.exe pack NativeUI.nuspec -properties Configuration=Release
Attempting to build package from 'NativeUI.nuspec'.
Successfully created package 'D:\Proyectos\NativeUI\NativeUI.1.7.0.nupkg'.
```

To get your packages on nuget.org, you need to [sign it](https://docs.microsoft.com/en-us/nuget/create-packages/sign-a-package) and then [upload it](https://docs.microsoft.com/en-us/nuget/create-packages/publish-a-package).

Closes #51 
