### PR TITLE
Fixing the Encoding and Line endings

### DIFF
--- a/NativeUI.nuspec
+++ b/NativeUI.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package >
   <metadata>
     <id>NativeUI</id>

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;


### PR DESCRIPTION
This is a simple change for compatibility and consistency with new and old .CS files.

This two are not using the same encoding and line ending compared to the rest of the files on the solution, so this should keep all of them equal.