### PR TITLE
The submenus now get the Banner and Offset from the parent menu

### DIFF
--- a/MenuExample.cs
+++ b/MenuExample.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Windows.Forms;
 using GTA;
-using GTA.Native;
 using NativeUI;
 
 public class MenuExample : Script

--- a/MenuPool.cs
+++ b/MenuPool.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using Control = GTA.Control;
@@ -60,12 +61,7 @@ namespace NativeUI
         /// <returns>The newly created submenu.</returns>
         public UIMenu AddSubMenu(UIMenu menu, string text)
         {
-            var item = new UIMenuItem(text);
-            menu.AddItem(item);
-            var submenu = new UIMenu(menu.Title.Caption, text);
-            this.Add(submenu);
-            menu.BindMenuToItem(submenu, item);
-            return submenu;
+            return AddSubMenu(menu, text, "", Point.Empty);
         }
 
         /// <summary>
@@ -77,16 +73,9 @@ namespace NativeUI
         /// <param name="text">The name of the submenu</param>
         /// <param name="offset">The offset of the menu</param>
         /// <returns>The newly created submenu.</returns>
-        public UIMenu AddSubMenu(UIMenu menu, string text, System.Drawing.Point offset)
+        public UIMenu AddSubMenu(UIMenu menu, string text, Point offset)
         {
-            var item = new UIMenuItem(text);
-            menu.AddItem(item);
-            var submenu = new UIMenu(menu.Title.Caption, text, offset);
-            
-            this.Add(submenu);
-            menu.BindMenuToItem(submenu, item);
-
-            return submenu;
+            return AddSubMenu(menu, text, "", offset);
         }
 
         /// <summary>
@@ -100,10 +89,24 @@ namespace NativeUI
         /// <returns>The newly created submenu.</returns>
         public UIMenu AddSubMenu(UIMenu menu, string text, string description)
         {
-            var item = new UIMenuItem(text, description);
+            return AddSubMenu(menu, text, description, Point.Empty);
+        }
+
+        /// <summary>
+        /// Create and add a submenu to the menu pool.
+        /// Adds an item with the given text and description to the menu, creates a corresponding submenu, and binds the submenu to the item.
+        /// The submenu inherits its title from the menu, and its subtitle from the item text.
+        /// </summary>
+        /// <param name="menu">The parent menu to which the submenu must be added.</param>
+        /// <param name="text">The name of the submenu.</param>
+        /// <param name="description">The name of the submenu.</param>
+        /// <returns>The newly created submenu.</returns>
+        public UIMenu AddSubMenu(UIMenu menu, string text, string description, Point offset)
+        {
+            UIMenuItem item = new UIMenuItem(text, description);
             menu.AddItem(item);
-            var submenu = new UIMenu(menu.Title.Caption, text);
-            this.Add(submenu);
+            UIMenu submenu = new UIMenu(menu.Title.Caption, text, offset);
+            Add(submenu);
             menu.BindMenuToItem(submenu, item);
             return submenu;
         }

--- a/MenuPool.cs
+++ b/MenuPool.cs
@@ -61,7 +61,10 @@ namespace NativeUI
         /// <returns>The newly created submenu.</returns>
         public UIMenu AddSubMenu(UIMenu menu, string text)
         {
-            return AddSubMenu(menu, text, "", Point.Empty);
+            Point Offset = Point.Empty;
+            if (OffsetInheritance)
+                Offset = menu.Offset;
+            return AddSubMenu(menu, text, "", Offset);
         }
 
         /// <summary>
@@ -89,7 +92,10 @@ namespace NativeUI
         /// <returns>The newly created submenu.</returns>
         public UIMenu AddSubMenu(UIMenu menu, string text, string description)
         {
-            return AddSubMenu(menu, text, description, Point.Empty);
+            Point Offset = Point.Empty;
+            if (OffsetInheritance)
+                Offset = menu.Offset;
+            return AddSubMenu(menu, text, description, Offset);
         }
 
         /// <summary>

--- a/MenuPool.cs
+++ b/MenuPool.cs
@@ -34,6 +34,10 @@ namespace NativeUI
         
         public bool DisableInstructionalButtons { set { _menuList.ForEach(m => m.DisableInstructionalButtons(value)); } }
 
+        public bool BannerInheritance = true;
+
+        public bool OffsetInheritance = true;
+
         private readonly List<UIMenu> _menuList = new List<UIMenu>();
 
 

--- a/MenuPool.cs
+++ b/MenuPool.cs
@@ -112,6 +112,12 @@ namespace NativeUI
             UIMenuItem item = new UIMenuItem(text, description);
             menu.AddItem(item);
             UIMenu submenu = new UIMenu(menu.Title.Caption, text, offset);
+            if (BannerInheritance && menu.BannerTexture != null)
+                submenu.SetBannerType(submenu.BannerTexture);
+            else if (BannerInheritance && menu.BannerRectangle != null)
+                submenu.SetBannerType(submenu.BannerRectangle);
+            else if (BannerInheritance && menu.BannerSprite != null)
+                submenu.SetBannerType(menu.BannerSprite);
             Add(submenu);
             menu.BindMenuToItem(submenu, item);
             return submenu;

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -147,6 +147,10 @@ namespace NativeUI
 
         public Point Offset;
 
+        public Sprite BannerSprite { get { return _logo; } }
+        public UIResRectangle BannerRectangle { get { return _tmpRectangle; } }
+        public string BannerTexture { get { return _customBanner; } }
+
         #endregion
 
         #region Events

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -145,7 +145,7 @@ namespace NativeUI
         public bool MouseControlsEnabled = true;
         public bool ScaleWithSafezone = true;
 
-        public Point Offset;
+        public Point Offset { get; }
 
         public Sprite BannerSprite { get { return _logo; } }
         public UIResRectangle BannerRectangle { get { return _tmpRectangle; } }

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -72,7 +72,6 @@ namespace NativeUI
 
         private readonly Scaleform _instructionalButtonsScaleform;
 
-        private Point _offset;
         private readonly int _extraYOffset;
 
         private static readonly MenuControls[] _menuControls = Enum.GetValues(typeof(MenuControls)).Cast<MenuControls>().ToArray();
@@ -145,6 +144,8 @@ namespace NativeUI
         public bool FormatDescriptions = true;
         public bool MouseControlsEnabled = true;
         public bool ScaleWithSafezone = true;
+
+        public Point Offset;
 
         #endregion
 
@@ -227,7 +228,7 @@ namespace NativeUI
         /// <param name="spriteName">Sprite name for the banner.</param>
         public UIMenu(string title, string subtitle, Point offset, string spriteLibrary, string spriteName)
         {
-            _offset = offset;
+            Offset = offset;
             Children = new Dictionary<UIMenuItem, UIMenu>();
             WidthOffset = 0;
 
@@ -235,30 +236,30 @@ namespace NativeUI
             UpdateScaleform();
 
             _mainMenu = new UIContainer(new Point(0, 0), new Size(700, 500), Color.FromArgb(0, 0, 0, 0));
-            _logo = new Sprite(spriteLibrary, spriteName, new Point(0 + _offset.X, 0 + _offset.Y), new Size(431, 107));
-            _mainMenu.Items.Add(Title = new UIResText(title, new Point(215 + _offset.X, 20 + _offset.Y), 1.15f, Color.White, Font.HouseScript, UIResText.Alignment.Centered));
+            _logo = new Sprite(spriteLibrary, spriteName, new Point(0 + Offset.X, 0 + Offset.Y), new Size(431, 107));
+            _mainMenu.Items.Add(Title = new UIResText(title, new Point(215 + Offset.X, 20 + Offset.Y), 1.15f, Color.White, Font.HouseScript, UIResText.Alignment.Centered));
             if (!String.IsNullOrWhiteSpace(subtitle))
             {
-                _mainMenu.Items.Add(new UIResRectangle(new Point(0 + offset.X, 107 + _offset.Y), new Size(431, 37), Color.Black));
-                _mainMenu.Items.Add(Subtitle = new UIResText(subtitle, new Point(8 + _offset.X, 110 + _offset.Y), 0.35f, Color.WhiteSmoke, 0, UIResText.Alignment.Left));
+                _mainMenu.Items.Add(new UIResRectangle(new Point(0 + offset.X, 107 + Offset.Y), new Size(431, 37), Color.Black));
+                _mainMenu.Items.Add(Subtitle = new UIResText(subtitle, new Point(8 + Offset.X, 110 + Offset.Y), 0.35f, Color.WhiteSmoke, 0, UIResText.Alignment.Left));
 
                 if (subtitle.StartsWith("~"))
                 {
                     CounterPretext = subtitle.Substring(0, 3);
                 }
-                _counterText = new UIResText("", new Point(425 + _offset.X, 110 + _offset.Y), 0.35f, Color.WhiteSmoke, 0, UIResText.Alignment.Right);
+                _counterText = new UIResText("", new Point(425 + Offset.X, 110 + Offset.Y), 0.35f, Color.WhiteSmoke, 0, UIResText.Alignment.Right);
                 _extraYOffset = 37;
             }
 
-            _upAndDownSprite = new Sprite("commonmenu", "shop_arrows_upanddown", new Point(190 + _offset.X, 147 + 37 * (MaxItemsOnScreen + 1) + _offset.Y - 37 + _extraYOffset), new Size(50, 50));
-            _extraRectangleUp = new UIResRectangle(new Point(0 + _offset.X, 144 + 38 * (MaxItemsOnScreen + 1) + _offset.Y - 37 + _extraYOffset), new Size(431, 18), Color.FromArgb(200, 0, 0, 0));
-            _extraRectangleDown = new UIResRectangle(new Point(0 + _offset.X, 144 + 18 + 38 * (MaxItemsOnScreen + 1) + _offset.Y - 37 + _extraYOffset), new Size(431, 18), Color.FromArgb(200, 0, 0, 0));
+            _upAndDownSprite = new Sprite("commonmenu", "shop_arrows_upanddown", new Point(190 + Offset.X, 147 + 37 * (MaxItemsOnScreen + 1) + Offset.Y - 37 + _extraYOffset), new Size(50, 50));
+            _extraRectangleUp = new UIResRectangle(new Point(0 + Offset.X, 144 + 38 * (MaxItemsOnScreen + 1) + Offset.Y - 37 + _extraYOffset), new Size(431, 18), Color.FromArgb(200, 0, 0, 0));
+            _extraRectangleDown = new UIResRectangle(new Point(0 + Offset.X, 144 + 18 + 38 * (MaxItemsOnScreen + 1) + Offset.Y - 37 + _extraYOffset), new Size(431, 18), Color.FromArgb(200, 0, 0, 0));
 
-            _descriptionBar = new UIResRectangle(new Point(_offset.X, 123), new Size(431, 4), Color.Black);
-            _descriptionRectangle = new Sprite("commonmenu", "gradient_bgd", new Point(_offset.X, 127), new Size(431, 30));
-            _descriptionText = new UIResText("Description", new Point(_offset.X + 5, 125), 0.35f, Color.FromArgb(255, 255, 255, 255), Font.ChaletLondon, UIResText.Alignment.Left);
+            _descriptionBar = new UIResRectangle(new Point(Offset.X, 123), new Size(431, 4), Color.Black);
+            _descriptionRectangle = new Sprite("commonmenu", "gradient_bgd", new Point(Offset.X, 127), new Size(431, 30));
+            _descriptionText = new UIResText("Description", new Point(Offset.X + 5, 125), 0.35f, Color.FromArgb(255, 255, 255, 255), Font.ChaletLondon, UIResText.Alignment.Left);
 
-            _background = new Sprite("commonmenu", "gradient_bgd", new Point(_offset.X, 144 + _offset.Y - 37 + _extraYOffset), new Size(290, 25));
+            _background = new Sprite("commonmenu", "gradient_bgd", new Point(Offset.X, 144 + Offset.Y - 37 + _extraYOffset), new Size(290, 25));
 
 
             SetKey(MenuControls.Up, Control.PhoneUp);
@@ -376,8 +377,8 @@ namespace NativeUI
         {
             WidthOffset = widthOffset;
             _logo.Size = new Size(431 + WidthOffset, 107);
-            _mainMenu.Items[0].Position = new Point((WidthOffset + _offset.X + 431) / 2, 20 + _offset.Y); // Title
-            _counterText.Position = new Point(425 + _offset.X + widthOffset, 110 + _offset.Y);
+            _mainMenu.Items[0].Position = new Point((WidthOffset + Offset.X + 431) / 2, 20 + Offset.Y); // Title
+            _counterText.Position = new Point(425 + Offset.X + widthOffset, 110 + Offset.Y);
             if (_mainMenu.Items.Count >= 1)
             {
                 var tmp = (UIResRectangle)_mainMenu.Items[1];
@@ -406,7 +407,7 @@ namespace NativeUI
         {
             _logo = spriteBanner;
             _logo.Size = new Size(431 + WidthOffset, 107);
-            _logo.Position = new Point(_offset.X, _offset.Y);
+            _logo.Position = new Point(Offset.X, Offset.Y);
         }
 
         /// <summary>
@@ -417,7 +418,7 @@ namespace NativeUI
         {
             _logo = null;
             _tmpRectangle = rectangle;
-            _tmpRectangle.Position = new Point(_offset.X, _offset.Y);
+            _tmpRectangle.Position = new Point(Offset.X, Offset.Y);
             _tmpRectangle.Size = new Size(431 + WidthOffset, 107);
         }
 
@@ -438,7 +439,7 @@ namespace NativeUI
         {
             int selectedItem = CurrentSelection;
 
-            item.Offset = _offset;
+            item.Offset = Offset;
             item.Parent = this;
             item.Position((MenuItems.Count * 25) - 37 + _extraYOffset);
             MenuItems.Add(item);
@@ -506,7 +507,7 @@ namespace NativeUI
 
             _extraRectangleDown.Size = new Size(431 + WidthOffset, 18);
 
-            _upAndDownSprite.Position = new Point(190 + _offset.X + (WidthOffset > 0 ? (WidthOffset / 2) : WidthOffset), 147 + 37 * (MaxItemsOnScreen + 1) + _offset.Y - 37 + _extraYOffset);
+            _upAndDownSprite.Position = new Point(190 + Offset.X + (WidthOffset > 0 ? (WidthOffset / 2) : WidthOffset), 147 + 37 * (MaxItemsOnScreen + 1) + Offset.Y - 37 + _extraYOffset);
 
             reDraw = false;
 
@@ -907,9 +908,9 @@ namespace NativeUI
         {
             //_descriptionText.WordWrap = new Size(425 + WidthOffset, 0);
 
-            _descriptionBar.Position = new Point(_offset.X, 149 - 37 + _extraYOffset + _offset.Y);
-            _descriptionRectangle.Position = new Point(_offset.X, 149 - 37 + _extraYOffset + _offset.Y);
-            _descriptionText.Position = new Point(_offset.X + 8, 155 - 37 + _extraYOffset + _offset.Y);
+            _descriptionBar.Position = new Point(Offset.X, 149 - 37 + _extraYOffset + Offset.Y);
+            _descriptionRectangle.Position = new Point(Offset.X, 149 - 37 + _extraYOffset + Offset.Y);
+            _descriptionText.Position = new Point(Offset.X + 8, 155 - 37 + _extraYOffset + Offset.Y);
 
             _descriptionBar.Size = new Size(431 + WidthOffset, 4);
             _descriptionRectangle.Size = new Size(431 + WidthOffset, 30);
@@ -918,9 +919,9 @@ namespace NativeUI
             if (count > MaxItemsOnScreen + 1)
                 count = MaxItemsOnScreen + 2;
 
-            _descriptionBar.Position = new Point(_offset.X, 38 * count + _descriptionBar.Position.Y);
-            _descriptionRectangle.Position = new Point(_offset.X, 38 * count + _descriptionRectangle.Position.Y);
-            _descriptionText.Position = new Point(_offset.X + 8, 38 * count + _descriptionText.Position.Y);
+            _descriptionBar.Position = new Point(Offset.X, 38 * count + _descriptionBar.Position.Y);
+            _descriptionRectangle.Position = new Point(Offset.X, 38 * count + _descriptionRectangle.Position.Y);
+            _descriptionText.Position = new Point(Offset.X + 8, 38 * count + _descriptionText.Position.Y);
         }
 
         /// <summary>
@@ -1017,7 +1018,7 @@ namespace NativeUI
             {
                 Point start = ((ScaleWithSafezone) ? safe : new Point(0, 0));
 
-                Sprite.DrawTexture(_customBanner, new Point(start.X + _offset.X, start.Y + _offset.Y), drawWidth);
+                Sprite.DrawTexture(_customBanner, new Point(start.X + Offset.X, start.Y + Offset.Y), drawWidth);
             }
             _mainMenu.Draw();
             if (MenuItems.Count == 0)
@@ -1120,8 +1121,8 @@ namespace NativeUI
 
             for (int i = _minItem; i <= limit; i++)
             {
-                int xpos = _offset.X + safezoneOffset.X;
-                int ypos = _offset.Y + 144 - 37 + _extraYOffset + (counter * 38) + safezoneOffset.Y;
+                int xpos = Offset.X + safezoneOffset.X;
+                int ypos = Offset.Y + 144 - 37 + _extraYOffset + (counter * 38) + safezoneOffset.Y;
                 int xsize = 431 + WidthOffset;
                 const int ysize = 38;
                 UIMenuItem uiMenuItem = MenuItems[i];
@@ -1166,8 +1167,8 @@ namespace NativeUI
                     uiMenuItem.Hovered = false;
                 counter++;
             }
-            int extraY = 144 + 38 * (MaxItemsOnScreen + 1) + _offset.Y - 37 + _extraYOffset + safezoneOffset.Y;
-            int extraX = safezoneOffset.X + _offset.X;
+            int extraY = 144 + 38 * (MaxItemsOnScreen + 1) + Offset.Y - 37 + _extraYOffset + safezoneOffset.Y;
+            int extraX = safezoneOffset.X + Offset.X;
             if (Size <= MaxItemsOnScreen + 1) return;
             if (IsMouseInBounds(new Point(extraX, extraY), new Size(431 + WidthOffset, 18)))
             {


### PR DESCRIPTION
This has been a pain in the ass, having to set the Offset and Banner on each and every one of the menus.

Now, every call to `MenuPool.AddSubMenu` sets the Offset and Banner from the parent/main menu.

You can disable this behaviour by setting `MenuPool.BannerInheritance` and `MenuPool.OffsetInheritance` to disable the Banner and Offset Inheritance respectively.