### PR TITLE
Added function to remove specific items with a predicate

### DIFF
--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -499,6 +499,23 @@ namespace NativeUI
             RecaulculateDescriptionPosition();
         }
 
+        /// <summary>
+        /// Removes the items that matches the predicate.
+        /// </summary>
+        /// <param name="predicate">The function to use as the check.</param>
+        public void Remove(Func<UIMenuItem, bool> predicate)
+        {
+            List<UIMenuItem> TempList = new List<UIMenuItem>(MenuItems);
+            foreach (var item in TempList)
+            {
+                if (predicate(item))
+                {
+                    MenuItems.Remove(item);
+                }
+            }
+            RecaulculateDescriptionPosition();
+        }
+
         private void DrawCalculations()
         {
             drawWidth = new Size(431 + WidthOffset, 107);


### PR DESCRIPTION
This is a function that I wanted to keep on my FiveM fork, but someone else might need it so here it is.

Under the hood, it does the following:

* Creates a clone of the list (to avoid removing items that no longer exists or removing the wrong items)
* Iterates over the items in the list
* Checks if the passed predicate/function is true
* If it does, the item gets removed from the original list
* Finally, `RecaulculateDescriptionPosition()` is called (for obvious reasons)