### PR TITLE
Added Closed and Opened event when UIMenu.Visible is changed

### DIFF
--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -19,6 +19,8 @@ namespace NativeUI
     public delegate void CheckboxChangeEvent(UIMenu sender, UIMenuCheckboxItem checkboxItem, bool Checked);
 
     public delegate void ItemSelectEvent(UIMenu sender, UIMenuItem selectedItem, int index);
+
+    public delegate void MenuOpenEvent(UIMenu sender);
 
     public delegate void MenuCloseEvent(UIMenu sender);
 
@@ -174,6 +176,11 @@ namespace NativeUI
         /// Called when user selects a simple item.
         /// </summary>
         public event ItemSelectEvent OnItemSelect;
+
+        /// <summary>
+        /// Called when user opens the menu.
+        /// </summary>
+        public event MenuOpenEvent OnMenuOpen;
 
         /// <summary>
         /// Called when user closes the menu or goes back in a menu chain.

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -1441,6 +1441,11 @@ namespace NativeUI
             OnCheckboxChange?.Invoke(this, sender, Checked);
         }
 
+        protected virtual void MenuOpenEv()
+        {
+            OnMenuOpen?.Invoke(this);
+        }
+
         protected virtual void MenuCloseEv()
         {
             OnMenuClose?.Invoke(this);

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -1327,6 +1327,10 @@ namespace NativeUI
             get { return _visible; }
             set
             {
+                if (value)
+                    MenuOpenEv();
+                else
+                    MenuCloseEv();
                 _visible = value;
                 _justOpened = value;
                 _itemsDirty = value;

--- a/UIMenu.cs
+++ b/UIMenu.cs
@@ -747,7 +747,6 @@ namespace NativeUI
                 if (ResetCursorOnOpen)
                     Cursor.Position = tmp;
             }
-            MenuCloseEv();
         }
 
 


### PR DESCRIPTION
I saw that there was a Closed event for when the menu returned to the previous event, so I moved that into UIMenu.Visible and added one similar for when is opened.

Closes #92 