### PR TITLE
Show MiddleFinger cursor when hovering the mouse over the label of the selected ListItem

### DIFF
--- a/NativeUI/UIMenu.cs
+++ b/NativeUI/UIMenu.cs
@@ -1182,12 +1182,20 @@ namespace NativeUI
             {
                 int xpos = Offset.X + safezoneOffset.X;
                 int ypos = Offset.Y + 144 - 37 + _extraYOffset + (counter * 38) + safezoneOffset.Y;
+                int yposSelected = Offset.Y + 144 - 37 + _extraYOffset + safezoneOffset.Y + CurrentSelection * 38;
                 int xsize = 431 + WidthOffset;
                 const int ysize = 38;
                 UIMenuItem uiMenuItem = MenuItems[i];
                 if (IsMouseInBounds(new Point(xpos, ypos), new Size(xsize, ysize)))
                 {
                     uiMenuItem.Hovered = true;
+                    int res = IsMouseInListItemArrows(MenuItems[i], new Point(xpos, yposSelected),
+                        safezoneOffset);
+                    if (uiMenuItem.Hovered && res == 1 && MenuItems[i] is IListItem)
+                    {
+                        Function.Call(Hash._0x8DB8CFFD58B62552, 5);
+                    }
+
                     if (Game.IsControlJustPressed(0, Control.Attack))
                         if (uiMenuItem.Selected && uiMenuItem.Enabled)
                         {
@@ -1195,8 +1203,6 @@ namespace NativeUI
                                 IsMouseInListItemArrows(MenuItems[i], new Point(xpos, ypos),
                                     safezoneOffset) > 0)
                             {
-                                int res = IsMouseInListItemArrows(MenuItems[i], new Point(xpos, ypos),
-                                    safezoneOffset);
                                 switch (res)
                                 {
                                     case 1:

--- a/NativeUI/UIMenu.cs
+++ b/NativeUI/UIMenu.cs
@@ -1195,7 +1195,6 @@ namespace NativeUI
                     {
                         Function.Call(Hash._0x8DB8CFFD58B62552, 5);
                     }
-
                     if (Game.IsControlJustPressed(0, Control.Attack))
                         if (uiMenuItem.Selected && uiMenuItem.Enabled)
                         {


### PR DESCRIPTION
Since the NativeUI is about creating menus in the original style, I thought it would be nice to bring the feature mentioned in the title to it.

Video here: [YouTube](https://www.youtube.com/watch?v=jrB1OGG3S_s)